### PR TITLE
Adding  as a default progress key

### DIFF
--- a/job_progress/job_progress.py
+++ b/job_progress/job_progress.py
@@ -97,8 +97,7 @@ class JobProgress(object):
             # There can be a race condition before we have saved amount.
             pending = int(self.amount) - sum(progress.values())
 
-        if pending:
-            progress[states.PENDING] = pending
+        progress[states.PENDING] = pending
 
         return progress
 


### PR DESCRIPTION
Based on my understanding, `pending` is a reflection of all tasks that have not been resolved. I find it useful to have a `pending` key if there are no pending tasks left. That way the client does not need to the arithmetic with successes/failures/amount.

cc @mkadin @dentafrice @charlax 
